### PR TITLE
Searching for port 80 also found 8080 and the like

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ program.arguments('<port>')
     let command;
 
     if (isWin) {
-      command = `netstat -aon | find ":${port}" | find "LISTENING"`;
+      command = `netstat -aon | find ":${port} " | find "LISTENING"`;
     } else {
       command = `lsof -i :${port} | awk '{ print $2; }' | head -n 2 | grep -v PID`;
     }


### PR DESCRIPTION
Below is output from my machine when I tried the command in the original script, which would have been run if I had run whoport with the argument `80`:

```
C:\Users\lewisje\Desktop>netstat -aon | find ":80" | find "LISTENING"
  TCP    0.0.0.0:8042           0.0.0.0:0              LISTENING       8224
  TCP    127.0.0.2:80           0.0.0.0:0              LISTENING       3040

C:\Users\lewisje\Desktop>netstat -aon | find ":80 " | find "LISTENING"
  TCP    127.0.0.2:80           0.0.0.0:0              LISTENING       3040
```

As you can see, the first example returned a process that was listening on port 8042, but I was only searching for port 80; also, although you may have only tested on Windows 7, [`netstat`](http://www.computerhope.com/netstat.htm) itself dates back to Windows 95 and NT, and the ever-useful `-o` option dates back to Windows Vista, so this script probably works in Windows 7 and later (and also Vista, if Node itself works in Vista, I haven't found documentation on supported Windows versions).
